### PR TITLE
Fix compile errors in retrieval docs

### DIFF
--- a/Retrieval.md
+++ b/Retrieval.md
@@ -63,7 +63,7 @@ SQLite.select()
   .async()
   .queryResultCallback(new QueryTransaction.QueryResultCallback<TestModel1>() {
       @Override
-      public void onQueryResult(QueryTransaction transaction, @NonNull CursorResult<TestModel1> tResult) {
+      public void onQueryResult(QueryTransaction<TestModel1> transaction, @NonNull CursorResult<TestModel1> tResult) {
 
       }
   }).execute();
@@ -82,7 +82,7 @@ FlowManager.getDatabaseForTable(TestModel1.class)
                         .where(TestModel1_Table.name.is("Async")))
                     .queryResult(new QueryTransaction.QueryResultCallback<TestModel1>() {
                         @Override
-                        public void onQueryResult(QueryTransaction transaction, @NonNull CursorResult<TestModel1> tResult) {
+                        public void onQueryResult(QueryTransaction<TestModel1> transaction, @NonNull CursorResult<TestModel1> tResult) {
 
                         }
                     }).build())


### PR DESCRIPTION
This change updates the retrieval page so that the examples pass the table class to the QueryTransaction.

In my testing of the queryResultCallback, I've had to provide the table class to the QueryTransaction in addition to the CursorResult. If I did not, I would get something similar to the following compile error:

Error:(65, 94) error: <anonymous com.test.test.TestModel1$1> is not abstract and does not override abstract method onQueryResult(QueryTransaction<TestModel1>,CursorResult<TestModel1>) in QueryResultCallback
Error:(67, 33) error: name clash: onQueryResult(QueryTransaction,CursorResult<TestModel1>) in <anonymous com.test.test.TestModel1$1> and onQueryResult(QueryTransaction<TResult>,CursorResult<TResult>) in QueryResultCallback have the same erasure, yet neither overrides the other
where TResult is a type-variable:
TResult extends Object declared in interface QueryResultCallback
Error:(66, 21) error: method does not override or implement a method from a supertype