### PR TITLE
Update dead link in Retrieval

### DIFF
--- a/Retrieval.md
+++ b/Retrieval.md
@@ -40,7 +40,7 @@ AnotherTable anotherObject = SQLite.select()
 
 ```
 
-To query custom objects or lists, see how to do so in [QueryModel](QueryModel.md).
+To query custom objects or lists, see how to do so in [QueryModel](QueryModels.md).
 
 Also you can query a `FlowCursorList`/`FlowTableList` from a query easily
 via `queryCursorList()` and the `queryTableList()` methods. To see more on these,


### PR DESCRIPTION
QueryModel.md was renamed to QueryModels.md at one point but the link in here was not updated to reflect that change.

Fixes #2